### PR TITLE
Browserify-friendly require.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,9 @@
-var libPath = process.env['CREATESEND_NODE_COV'] ? './lib-cov' : './lib';
+var createsend;
 
-module.exports = require(libPath + '/createsend');
+if (process.env['CREATESEND_NODE_COV']) {
+  createsend = require('./lib-cov/createsend');
+} else {
+  createsend = require('./lib/createsend');  
+}
+
+module.exports = createsend;


### PR DESCRIPTION
When compiling in a package for AWS Lambda, dynamic requires do not work. This is resolved with a simple `if` statement.