### PR TITLE
Fixed updateTemplate method for Templates.

### DIFF
--- a/lib/interface/templates.js
+++ b/lib/interface/templates.js
@@ -24,6 +24,6 @@ Templates.prototype = {
     },
 
     updateTemplate: function (templateId, details, callback) {
-        new Template(this.createsend, templateId).updateTemplate(details, callback);
+        new Template(this.createsend, templateId).update(details, callback);
     }
 }


### PR DESCRIPTION
The 'updateTemplate' method doesn't exist on the template object. Renamed to 'update'.